### PR TITLE
Drops "API" prefix from application URL routing

### DIFF
--- a/crc_service_portal/apps/allocations/urls.py
+++ b/crc_service_portal/apps/allocations/urls.py
@@ -13,6 +13,6 @@ api_router.register(r'allocations', AllocationViewSet)
 api_router.register(r'proposals', ProposalViewSet)
 
 urlpatterns = [
-    path('api/', include(api_router.urls)),
-    path('allocations', AllocationsView.as_view(), name='allocations'),
+    path('', include(api_router.urls)),
+    path('allocations_demo', AllocationsView.as_view(), name='allocations'),
 ]

--- a/crc_service_portal/apps/research_products/urls.py
+++ b/crc_service_portal/apps/research_products/urls.py
@@ -8,9 +8,9 @@ from .views import *
 app_name = 'research_products'
 
 api_router = DefaultRouter()
-api_router.register(r'clusters', PublicationViewSet)
-api_router.register(r'allocations', GrantViewSet)
+api_router.register(r'publications', PublicationViewSet)
+api_router.register(r'grants', GrantViewSet)
 
 urlpatterns = [
-    path('api/', include(api_router.urls)),
+    path('', include(api_router.urls)),
 ]

--- a/crc_service_portal/main/settings.py
+++ b/crc_service_portal/main/settings.py
@@ -125,6 +125,10 @@ REST_FRAMEWORK = {
     ],
 }
 
+# Disable the api GUI if not in debug mode
+if DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'].append('rest_framework.renderers.BrowsableAPIRenderer')
+
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 

--- a/crc_service_portal/main/urls.py
+++ b/crc_service_portal/main/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('', TemplateView.as_view(template_name='index.html'), name='home'),
     path('alloc/', include('apps.allocations.urls', namespace='alloc')),
     path('auth/', include('apps.jwt.urls', namespace='jwt')),
+    path('prod/', include('apps.research_products.urls', namespace='research_products')),
 ]


### PR DESCRIPTION
Changes url patterns from `path('api/', include(...)),` to `path('', include(...)),`.