### PR TITLE
Require JWT authentication when running in production

### DIFF
--- a/crc_service_api/apps/authentication/urls.py
+++ b/crc_service_api/apps/authentication/urls.py
@@ -3,7 +3,7 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-app_name = 'authorization'
+app_name = 'authentication'
 
 urlpatterns = [
     path('new/', TokenObtainPairView.as_view(), name='token_obtain'),

--- a/crc_service_api/apps/docs/urls.py
+++ b/crc_service_api/apps/docs/urls.py
@@ -8,5 +8,5 @@ app_name = 'docs'
 
 urlpatterns = [
     path('openapi', SchemaView, name='openapi-schema'),
-    path('', RedocView, name='redoc'),
+    path('', RedocView.as_view(), name='redoc'),
 ]

--- a/crc_service_api/apps/docs/views.py
+++ b/crc_service_api/apps/docs/views.py
@@ -4,8 +4,6 @@ View objects handle the processing of incoming HTTP requests and return the
 appropriately rendered HTML template or other HTTP response.
 """
 
-import importlib.metadata
-
 from django.conf import settings
 from django.views.generic import TemplateView
 from rest_framework.schemas import get_schema_view
@@ -15,11 +13,14 @@ __all__ = ['RedocView', 'SchemaView']
 SchemaView = get_schema_view(
     title="CRC Self Service API",
     description="A REST API for managing user resource allocations on HPC systems.",
-    version=settings.VERSION
+    version=settings.VERSION,
+    permission_classes=[]
 )
 
-# The `schema_url` assumes the application is installed under the namespace `docs`
-RedocView = TemplateView.as_view(
-    template_name='api_docs/redoc.html',
-    extra_context={'schema_url': 'docs:openapi-schema'}
-)
+
+class RedocView(TemplateView):
+    """View for rendering API documentation using Redoc"""
+
+    # The `schema_url` assumes the application is installed under the namespace `docs`
+    extra_context = {'schema_url': 'docs:openapi-schema'}
+    template_name = 'api_docs/redoc.html'

--- a/crc_service_api/apps/health/views.py
+++ b/crc_service_api/apps/health/views.py
@@ -7,10 +7,9 @@ appropriately rendered HTML template or other HTTP response.
 from django.core.handlers.wsgi import HttpRequest
 from django.http import JsonResponse
 from health_check.mixins import CheckMixin
+from rest_framework.viewsets import ViewSet
 
 __all__ = ['HealthCheckViewSet']
-
-from rest_framework.viewsets import ViewSet
 
 
 class HealthCheckViewSet(CheckMixin, ViewSet):

--- a/crc_service_api/main/settings.py
+++ b/crc_service_api/main/settings.py
@@ -130,14 +130,14 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-    ],
-    # 'DEFAULT_PERMISSION_CLASSES': [
-    #     'rest_framework.permissions.IsAuthenticated',
-    # ]
+    ]
 }
 
 if DEBUG:  # Disable the API GUI if not in debug mode
     REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'].append('rest_framework.renderers.BrowsableAPIRenderer')
+
+else:  # Only enforce API permissions in production
+    REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'] = ['rest_framework.permissions.IsAuthenticated']
 
 # Celery scheduler
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', "redis://127.0.0.1:6379/0")

--- a/crc_service_api/main/settings.py
+++ b/crc_service_api/main/settings.py
@@ -117,8 +117,7 @@ JAZZMIN_SETTINGS = {
         "research_products",
         "sites"
     ],
-    "icons": {
-    },
+    "icons": {},
     "site_logo": "theme/img/logo/Shield_White.png",
     "login_logo": "theme/img/logo/Pitt_Primary_3Color_small.png",
 }
@@ -132,9 +131,12 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
+    # 'DEFAULT_PERMISSION_CLASSES': [
+    #     'rest_framework.permissions.IsAuthenticated',
+    # ]
 }
 
-if DEBUG:  # Disable the api GUI if not in debug mode
+if DEBUG:  # Disable the API GUI if not in debug mode
     REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'].append('rest_framework.renderers.BrowsableAPIRenderer')
 
 # Celery scheduler

--- a/crc_service_api/main/urls.py
+++ b/crc_service_api/main/urls.py
@@ -10,7 +10,9 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('allocations/', include('apps.allocations.urls', namespace='alloc')),
     path('authentication/', include('apps.authentication.urls', namespace='authentication')),
-    path('docs/', include('apps.docs.urls', namespace='docs')),
     path('health/', include('apps.health.urls', namespace='health')),
     path('products/', include('apps.research_products.urls', namespace='research_products')),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(path('docs/', include('apps.docs.urls', namespace='docs')))

--- a/crc_service_api/main/urls.py
+++ b/crc_service_api/main/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path('', lambda *args: HttpResponse(f"Service Portal API Version {settings.VERSION}"), name='home'),
     path('admin/', admin.site.urls),
     path('allocations/', include('apps.allocations.urls', namespace='alloc')),
-    path('authorization/', include('apps.authorization.urls', namespace='authorization')),
+    path('authentication/', include('apps.authentication.urls', namespace='authentication')),
     path('docs/', include('apps.docs.urls', namespace='docs')),
     path('health/', include('apps.health.urls', namespace='health')),
     path('products/', include('apps.research_products.urls', namespace='research_products')),


### PR DESCRIPTION
Updates application settings to require JWT authentication in production. Some other edits are also included to ensure all API endpoints are properly discovered by the documentation generator.